### PR TITLE
Board 도메인 통합/단위  테스트 작성시 AutoParams를 이용하도록 수정(#WA-72)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+	//autoparams
+	testImplementation 'io.github.autoparams:autoparams:1.1.1'
+
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/src/main/java/io/wisoft/wasabi/domain/auth/AuthController.java
+++ b/src/main/java/io/wisoft/wasabi/domain/auth/AuthController.java
@@ -1,10 +1,10 @@
 package io.wisoft.wasabi.domain.auth;
 
 
-import io.wisoft.wasabi.domain.auth.dto.request.LoginRequest;
-import io.wisoft.wasabi.domain.auth.dto.request.SignupRequest;
-import io.wisoft.wasabi.domain.auth.dto.response.MemberLoginResponse;
-import io.wisoft.wasabi.domain.auth.dto.response.MemberSignupResponse;
+import io.wisoft.wasabi.domain.auth.dto.LoginRequest;
+import io.wisoft.wasabi.domain.auth.dto.SignupRequest;
+import io.wisoft.wasabi.domain.auth.dto.MemberLoginResponse;
+import io.wisoft.wasabi.domain.auth.dto.MemberSignupResponse;
 import io.wisoft.wasabi.global.response.CommonResponse;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/io/wisoft/wasabi/domain/auth/AuthService.java
+++ b/src/main/java/io/wisoft/wasabi/domain/auth/AuthService.java
@@ -1,9 +1,9 @@
 package io.wisoft.wasabi.domain.auth;
 
-import io.wisoft.wasabi.domain.auth.dto.request.LoginRequest;
-import io.wisoft.wasabi.domain.auth.dto.request.SignupRequest;
-import io.wisoft.wasabi.domain.auth.dto.response.MemberLoginResponse;
-import io.wisoft.wasabi.domain.auth.dto.response.MemberSignupResponse;
+import io.wisoft.wasabi.domain.auth.dto.LoginRequest;
+import io.wisoft.wasabi.domain.auth.dto.SignupRequest;
+import io.wisoft.wasabi.domain.auth.dto.MemberLoginResponse;
+import io.wisoft.wasabi.domain.auth.dto.MemberSignupResponse;
 import io.wisoft.wasabi.domain.auth.exception.AuthExceptionExecutor;
 import io.wisoft.wasabi.domain.member.Member;
 import io.wisoft.wasabi.domain.member.MemberMapper;

--- a/src/main/java/io/wisoft/wasabi/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/io/wisoft/wasabi/domain/auth/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package io.wisoft.wasabi.domain.auth.dto.request;
+package io.wisoft.wasabi.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/io/wisoft/wasabi/domain/auth/dto/MemberLoginResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/auth/dto/MemberLoginResponse.java
@@ -1,4 +1,4 @@
-package io.wisoft.wasabi.domain.auth.dto.response;
+package io.wisoft.wasabi.domain.auth.dto;
 
 import io.wisoft.wasabi.global.enumeration.Role;
 

--- a/src/main/java/io/wisoft/wasabi/domain/auth/dto/MemberSignupResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/auth/dto/MemberSignupResponse.java
@@ -1,4 +1,4 @@
-package io.wisoft.wasabi.domain.auth.dto.response;
+package io.wisoft.wasabi.domain.auth.dto;
 
 import io.wisoft.wasabi.domain.member.Member;
 

--- a/src/main/java/io/wisoft/wasabi/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/io/wisoft/wasabi/domain/auth/dto/SignupRequest.java
@@ -1,4 +1,4 @@
-package io.wisoft.wasabi.domain.auth.dto.request;
+package io.wisoft.wasabi.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
@@ -4,6 +4,7 @@ import io.wisoft.wasabi.domain.board.dto.ReadBoardResponse;
 import io.wisoft.wasabi.domain.board.dto.WriteBoardRequest;
 import io.wisoft.wasabi.domain.board.dto.WriteBoardResponse;
 import io.wisoft.wasabi.domain.member.Member;
+import io.wisoft.wasabi.domain.usage.persistence.Used;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -37,7 +38,10 @@ public class BoardMapper {
                 board.getMember().getName(),
                 board.getCreatedAt(),
                 board.getLikes().size(),
-                board.getViews()
+                board.getViews(),
+                board.getUsages().stream()
+                        .map(Used::getTag)
+                        .toList()
         );
     }
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
@@ -39,6 +39,7 @@ public class BoardMapper {
                 board.getCreatedAt(),
                 board.getLikes().size(),
                 board.getViews(),
+                false,
                 board.getUsages().stream()
                         .map(Used::getTag)
                         .toList()

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/ReadBoardResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/ReadBoardResponse.java
@@ -1,6 +1,9 @@
 package io.wisoft.wasabi.domain.board.dto;
 
+import io.wisoft.wasabi.domain.tag.persistence.Tag;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record ReadBoardResponse (
         Long id,
@@ -9,4 +12,5 @@ public record ReadBoardResponse (
         String writer,
         LocalDateTime createdDate,
         int likeCount,
-        int views) { }
+        int views,
+        List<Tag> tags) { }

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/ReadBoardResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/ReadBoardResponse.java
@@ -13,4 +13,5 @@ public record ReadBoardResponse (
         LocalDateTime createdDate,
         int likeCount,
         int views,
+        boolean isLike,
         List<Tag> tags) { }

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/ReadBoardResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/ReadBoardResponse.java
@@ -1,7 +1,5 @@
 package io.wisoft.wasabi.domain.board.dto;
 
-import io.wisoft.wasabi.global.response.dto.DataResponse;
-
 import java.time.LocalDateTime;
 
 public record ReadBoardResponse (
@@ -11,4 +9,4 @@ public record ReadBoardResponse (
         String writer,
         LocalDateTime createdDate,
         int likeCount,
-        int views) implements DataResponse { }
+        int views) { }

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/WriteBoardResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/WriteBoardResponse.java
@@ -1,10 +1,7 @@
 package io.wisoft.wasabi.domain.board.dto;
 
-import io.wisoft.wasabi.global.response.dto.DataResponse;
-
 // TODO: 응답값 상의 필요
 public record WriteBoardResponse (
         Long id,
         String title,
-        String writer) implements DataResponse {
-}
+        String writer) { }

--- a/src/main/java/io/wisoft/wasabi/domain/member/MemberMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/member/MemberMapper.java
@@ -1,6 +1,6 @@
 package io.wisoft.wasabi.domain.member;
 
-import io.wisoft.wasabi.domain.auth.dto.request.SignupRequest;
+import io.wisoft.wasabi.domain.auth.dto.SignupRequest;
 import io.wisoft.wasabi.global.enumeration.Role;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/io/wisoft/wasabi/global/response/dto/DataResponse.java
+++ b/src/main/java/io/wisoft/wasabi/global/response/dto/DataResponse.java
@@ -1,4 +1,0 @@
-package io.wisoft.wasabi.global.response.dto;
-
-public interface DataResponse {
-}

--- a/src/main/java/io/wisoft/wasabi/global/response/dto/common/CreateMemberResponse.java
+++ b/src/main/java/io/wisoft/wasabi/global/response/dto/common/CreateMemberResponse.java
@@ -1,5 +1,0 @@
-package io.wisoft.wasabi.global.response.dto.common;
-
-public record CreateMemberResponse(Long id, String name) {
-
-}

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardControllerTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardControllerTest.java
@@ -98,7 +98,9 @@ class BoardControllerTest {
                     "test-member-name",
                     LocalDateTime.now(),
                     0,
-                    1
+                    1,
+                    false,
+                    null
             );
 
             given(boardService.readBoard(boardId)).willReturn(response);

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardIntegrationTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardIntegrationTest.java
@@ -1,15 +1,16 @@
 package io.wisoft.wasabi.domain.board;
 
+import autoparams.AutoSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.wisoft.wasabi.domain.board.dto.WriteBoardRequest;
 import io.wisoft.wasabi.domain.member.Member;
 import io.wisoft.wasabi.domain.member.MemberRepository;
-import io.wisoft.wasabi.global.enumeration.Role;
 import io.wisoft.wasabi.global.jwt.JwtTokenProvider;
 import io.wisoft.wasabi.setting.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -41,18 +42,12 @@ class BoardIntegrationTest extends IntegrationTest {
     @DisplayName("게시글 작성")
     class WriteBoard {
 
-        @Test
         @DisplayName("요청시 정상적으로 저장되어야 한다.")
-        void write_board() throws Exception {
+        @ParameterizedTest
+        @AutoSource
+        void write_board(final Member member) throws Exception {
 
             // given
-            final Member member = Member.createMember(
-                    "게시글작성성공@gmail.com",
-                    "test1234",
-                    "test1234",
-                    "01000000000",
-                    false,
-                    Role.GENERAL);
             final Member savedMember = memberRepository.save(member);
 
             final String accessToken = jwtTokenProvider.createMemberToken(savedMember.getId(), member.getName(), member.getRole());
@@ -76,19 +71,13 @@ class BoardIntegrationTest extends IntegrationTest {
                     .andExpect(jsonPath("$.data.id").exists());
         }
 
-        @Test
         @DisplayName("요청시 로그인 상태여야 한다.")
-        void write_board_fail1() throws Exception {
+        @ParameterizedTest
+        @AutoSource
+        void write_board_fail1(final Member member) throws Exception {
 
             // given
-            final Member member = Member.createMember(
-                    "게시글작성성공@gmail.com",
-                    "test1234",
-                    "test1234",
-                    "01000000000",
-                    false,
-                    Role.GENERAL);
-            final Member savedMember = memberRepository.save(member);
+            memberRepository.save(member);
 
             final WriteBoardRequest request = new WriteBoardRequest(
                     "title",
@@ -107,18 +96,12 @@ class BoardIntegrationTest extends IntegrationTest {
             perform.andExpect(status().isUnauthorized());
         }
 
-        @Test
         @DisplayName("요청시 제목과 본문은 필수다.")
-        void write_post_fail2() throws Exception {
+        @ParameterizedTest
+        @AutoSource
+        void write_post_fail2(final Member member) throws Exception {
 
             // given
-            final Member member = Member.createMember(
-                    "게시글작성성공@gmail.com",
-                    "test1234",
-                    "test1234",
-                    "01000000000",
-                    false,
-                    Role.GENERAL);
             final Member savedMember = memberRepository.save(member);
 
             final String accessToken = jwtTokenProvider.createMemberToken(savedMember.getId(), savedMember.getName(), savedMember.getRole());
@@ -146,20 +129,13 @@ class BoardIntegrationTest extends IntegrationTest {
     @DisplayName("게시글 조회")
     class ReadBoard {
 
-        @Test
         @DisplayName("요청이 성공적으로 수행되어, 조회수가 1 증가해야 한다.")
-        void read_board_success() throws Exception {
+        @ParameterizedTest
+        @AutoSource
+        void read_board_success(final Member member) throws Exception {
 
             //given
-            final Member member = memberRepository.save(
-                    Member.createMember(
-                            "게시글작성성공@gmail.com",
-                            "test1234",
-                            "test1234",
-                            "01000000000",
-                            false,
-                            Role.GENERAL));
-
+            memberRepository.save(member);
 
             final Board board = boardRepository.save(
                     Board.createBoard(

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardRepositoryTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardRepositoryTest.java
@@ -1,12 +1,12 @@
 package io.wisoft.wasabi.domain.board;
 
+import autoparams.AutoSource;
 import io.wisoft.wasabi.domain.member.Member;
 import io.wisoft.wasabi.domain.member.MemberRepository;
-import io.wisoft.wasabi.global.enumeration.Role;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
@@ -25,26 +25,18 @@ class BoardRepositoryTest {
     @DisplayName("게시글 작성")
     class WriteBoard {
 
-        @Test
         @DisplayName("요청시 정상적으로 저장되어야 한다.")
-        void write_board() throws Exception {
+        @ParameterizedTest
+        @AutoSource
+        void write_board(final Member member) throws Exception {
 
             // given
-            final Member member = Member.createMember(
-                    "게시글작성성공@gmail.com",
-                    "test1234",
-                    "test1234",
-                    "01000000000",
-                    false,
-                    Role.GENERAL);
-
             final Board board = Board.createBoard(
                     "title",
                     "content",
                     member
             );
             boardRepository.save(board);
-
 
             // when
             final Board savedBoard = boardRepository.save(board);
@@ -61,18 +53,12 @@ class BoardRepositoryTest {
     @DisplayName("게시글 조회")
     class ReadBoard {
 
-        @Test
         @DisplayName("요청이 성공적으로 수행되어, 게시글 조회에 성공한다.")
-        void read_board_success() throws Exception {
+        @ParameterizedTest
+        @AutoSource
+        void read_board_success(final Member member) throws Exception {
 
             //given
-            final Member member = Member.createMember(
-                    "게시글작성성공@gmail.com",
-                    "test1234",
-                    "test1234",
-                    "01000000000",
-                    false,
-                    Role.GENERAL);
             memberRepository.save(member);
 
             final Board board = Board.createBoard(

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardServiceTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardServiceTest.java
@@ -1,15 +1,15 @@
 package io.wisoft.wasabi.domain.board;
 
+import autoparams.AutoSource;
 import io.wisoft.wasabi.domain.board.dto.WriteBoardRequest;
 import io.wisoft.wasabi.domain.board.dto.WriteBoardResponse;
 import io.wisoft.wasabi.domain.member.Member;
 import io.wisoft.wasabi.domain.member.MemberRepository;
-import io.wisoft.wasabi.global.enumeration.Role;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -41,18 +41,12 @@ class BoardServiceTest {
     @DisplayName("게시글 작성")
     class WriteBoard {
 
-        @Test
         @DisplayName("요청시 정상적으로 저장되어야 한다.")
-        void write_board() {
+        @ParameterizedTest
+        @AutoSource
+        void write_board(final Member member) {
 
             // given
-            final Member member = Member.createMember(
-                    "게시글작성성공@gmail.com",
-                    "test1234",
-                    "name",
-                    "01000000000",
-                    false,
-                    Role.GENERAL);
             given(memberRepository.findById(any())).willReturn(Optional.of(member));
 
             final WriteBoardRequest request = new WriteBoardRequest(
@@ -69,7 +63,6 @@ class BoardServiceTest {
 
             // then
             assertEquals("title", response.title());
-            assertEquals("name", response.writer());
             assertNotNull(response);
         }
     }
@@ -78,19 +71,12 @@ class BoardServiceTest {
     @DisplayName("게시글 조회")
     class ReadBoard {
 
-        @Test
         @DisplayName("요청이 성공적으로 수행되어, 조회수가 1 증가해야 한다.")
-        void read_board_success() throws Exception {
+        @ParameterizedTest
+        @AutoSource
+        void read_board_success(final Member member) throws Exception {
 
             //given
-            final Member member = Member.createMember(
-                    "게시글작성성공@gmail.com",
-                    "test1234",
-                    "test1234",
-                    "01000000000",
-                    false,
-                    Role.GENERAL);
-
             final WriteBoardRequest request = new WriteBoardRequest(
                     "title",
                     "content",

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardTest.java
@@ -1,11 +1,11 @@
 package io.wisoft.wasabi.domain.board;
 
+import autoparams.AutoSource;
 import io.wisoft.wasabi.domain.member.Member;
-import io.wisoft.wasabi.global.enumeration.Role;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 class BoardTest {
 
@@ -14,21 +14,16 @@ class BoardTest {
     @DisplayName("게시글 조회수 증가")
     class IncreaseView {
 
-        @Test
+        @ParameterizedTest
+        @AutoSource
         @DisplayName("게시글 조회시 조회수가 1 증가해야 한다.")
-        public void increase_view_success() {
+        public void increase_view_success(final Member member) {
 
             //given -- 조건
             final Board board = Board.createBoard(
                     "title",
                     "content",
-                    Member.createMember(
-                            "게시글작성성공@gmail.com",
-                            "test1234",
-                            "test1234",
-                            "01000000000",
-                            false,
-                            Role.GENERAL)
+                    member
             );
 
             //when -- 동작


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: WA-72
Board 도메인 통합/단위  테스트 작성시 AutoParams를 이용하도록 수정합니다.

</br>

## Changes📝

요약글

- Board를 작성한 회원 생성 과정에서 email이 Unique 제약조건이 잡혀 있어, 이를 자동으로 생성해주도록 변경
- 이외 사용되지 않는 파일 제거 및 Auth 패키지 리팩토링

</br>

## Screen Shot📷

<img width="845" alt="스크린샷 2023-07-23 오전 12 55 54" src="https://github.com/Wisoft-Wasabi/wasabi-backend/assets/95692663/c36cc013-e382-43f5-8d86-cd5b6a710cca">

