### PR TITLE
refactor: 게시글 목록 정렬 조회 기능 Query DSL을 사용해 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,57 +1,81 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.0'
-	id 'io.spring.dependency-management' version '1.1.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.0'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'io.wisoft'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 
-	configureEach {
-		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
-	}
+    configureEach {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
 
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	implementation 'org.mindrot:jbcrypt:0.4'
+    implementation 'org.mindrot:jbcrypt:0.4'
 
-	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
-	//autoparams
-	testImplementation 'io.github.autoparams:autoparams:1.1.1'
+    //autoparams
+    testImplementation 'io.github.autoparams:autoparams:1.1.1'
 
-	// mysql
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// log4j2
-	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-	implementation 'com.lmax:disruptor:3.4.2'
+    // log4j2
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    implementation 'com.lmax:disruptor:3.4.2'
+
+    // Query DSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+// Q타입 클래스 생성 경로
+def generated = "$buildDir/generated/qclass"
+
+// QueryDSL QClass 파일 생성 위치 설정
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set에 QueryDSL QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardController.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardController.java
@@ -6,14 +6,11 @@ import io.wisoft.wasabi.global.config.common.annotation.MemberId;
 import io.wisoft.wasabi.global.config.web.response.Response;
 import io.wisoft.wasabi.global.config.web.response.ResponseType;
 import jakarta.validation.Valid;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequestMapping("/boards")
@@ -32,10 +29,10 @@ public class BoardController<T> {
 
         final WriteBoardResponse data = boardService.writeBoard(request, memberId);
         return ResponseEntity.ofNullable(
-            Response.of(
-                ResponseType.BOARD_WRITE_SUCCESS,
-                data
-            )
+                Response.of(
+                        ResponseType.BOARD_WRITE_SUCCESS,
+                        data
+                )
         );
     }
 
@@ -45,24 +42,24 @@ public class BoardController<T> {
 
         final ReadBoardResponse data = boardService.readBoard(boardId, accessId);
         return ResponseEntity.ofNullable(
-            Response.of(
-                ResponseType.BOARD_READ_SUCCESS,
-                data
-            )
+                Response.of(
+                        ResponseType.BOARD_READ_SUCCESS,
+                        data
+                )
         );
     }
 
     @GetMapping
-    public ResponseEntity<Response<Slice<SortBoardResponse>>> sortedBoards(
+    public ResponseEntity<Response<Slice<SortBoardResponse>>> boardList(
             @RequestParam(name = "sortBy", defaultValue = "default") final String sortBy,
             @PageableDefault(size = 2) final Pageable pageable) {
 
-        final Slice<SortBoardResponse> data = boardService.getSortedBoards(sortBy, pageable);
+        final Slice<SortBoardResponse> data = boardService.getBoardList(sortBy, pageable);
         return ResponseEntity.ofNullable(
-            Response.of(
-                ResponseType.BOARD_SORTED_LIST_SUCCESS,
-                data
-            )
+                Response.of(
+                        ResponseType.BOARD_SORTED_LIST_SUCCESS,
+                        data
+                )
         );
     }
 
@@ -71,10 +68,10 @@ public class BoardController<T> {
         final Slice<MyBoardsResponse> data = boardService.getMyBoards(memberId, pageable);
 
         return ResponseEntity.ofNullable(
-            Response.of(
-                ResponseType.MY_BOARD_LIST_SUCCESS,
-                data
-            )
+                Response.of(
+                        ResponseType.MY_BOARD_LIST_SUCCESS,
+                        data
+                )
         );
     }
 
@@ -83,10 +80,10 @@ public class BoardController<T> {
         final Slice<MyLikeBoardsResponse> data = boardService.getMyLikeBoards(memberId, pageable);
 
         return ResponseEntity.ofNullable(
-            Response.of(
-                ResponseType.MY_LIKE_BOARD_LIST_SUCCESS,
-                data
-            )
+                Response.of(
+                        ResponseType.MY_LIKE_BOARD_LIST_SUCCESS,
+                        data
+                )
         );
     }
 

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
@@ -60,8 +60,7 @@ public class BoardMapper {
                 board.getMember().getName(),
                 board.getCreatedAt(),
                 board.getLikes().size(),
-                board.getViews(),
-                false
+                board.getViews()
         ));
     }
 

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
@@ -53,17 +53,6 @@ public class BoardMapper {
         );
     }
 
-    public Slice<SortBoardResponse> entityToSortBoardResponse(final Slice<Board> boards) {
-        return boards.map(board -> new SortBoardResponse(
-                board.getId(),
-                board.getTitle(),
-                board.getMember().getName(),
-                board.getCreatedAt(),
-                board.getLikes().size(),
-                board.getViews()
-        ));
-    }
-
     public Slice<MyBoardsResponse> entityToMyBoardsResponse(final Slice<Board> myBoards) {
 
         return myBoards.map(board -> new MyBoardsResponse(

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardQueryRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardQueryRepository.java
@@ -1,0 +1,76 @@
+package io.wisoft.wasabi.domain.board;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.wisoft.wasabi.domain.board.dto.SortBoardResponse;
+import io.wisoft.wasabi.domain.like.QLike;
+import io.wisoft.wasabi.domain.member.QMember;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class BoardQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QBoard board = QBoard.board;
+    private final QMember member = QMember.member;
+    private final QLike like = QLike.like;
+
+    public BoardQueryRepository(final JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    public Slice<SortBoardResponse> boardList(final Pageable pageable,
+                                              final BoardSortType sortType) {
+
+        final ConstructorExpression<SortBoardResponse> boardResponse =
+                Projections.constructor(
+                        SortBoardResponse.class,
+                        board.id,
+                        board.title,
+                        board.member.name,
+                        board.createdAt,
+                        like.count(),
+                        board.views
+                );
+
+        final List<SortBoardResponse> result = jpaQueryFactory
+                .query()
+                .select(boardResponse)
+                .from(board)
+                .join(member)
+                .on(board.member.eq(member))
+                .leftJoin(like)
+                .on(like.board.eq(board))
+                .groupBy(board.id)
+                .orderBy(ordering(sortType))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (result.size() > pageable.getPageSize()) {
+            result.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(result, pageable, hasNext);
+    }
+
+    private OrderSpecifier ordering(final BoardSortType sortType) {
+
+        return switch (sortType) {
+
+            case VIEWS -> board.views.desc();
+            case LATEST -> board.createdAt.desc();
+            case LIKES -> like.count().desc();
+            default -> board.createdAt.desc();
+        };
+    }
+}

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardRepository.java
@@ -7,21 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    // 기본값
-    @Query("SELECT board FROM Board board")
-    Slice<Board> findDefaultBoards(final Pageable pageable);
-
-    // 최신순
-    @Query("SELECT board FROM Board board ORDER BY board.createdAt DESC")
-    Slice<Board> findAllByOrderByCreatedAtDesc(Pageable pageable);
-
-    // 조회수
-    @Query("SELECT board FROM Board board ORDER BY board.views DESC")
-    Slice<Board> findAllByOrderByViewsDesc(Pageable pageable);
-
-    // 좋아요 순
-    @Query("SELECT board FROM Board board ORDER BY SIZE(board.likes) DESC")
-    Slice<Board> findAllByOrderByLikesDesc(Pageable pageable);
 
     @Query("SELECT board FROM Board board " +
             "LEFT JOIN FETCH board.likes " +

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardService.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardService.java
@@ -10,7 +10,7 @@ public interface BoardService<T> {
 
     ReadBoardResponse readBoard(final Long boardId, final Long accessId);
 
-    Slice<SortBoardResponse> getSortedBoards(final String sortBy,final Pageable pageable);
+    Slice<SortBoardResponse> getBoardList(final String sortBy, final Pageable pageable);
 
     Slice<MyBoardsResponse> getMyBoards(final Long memberId, final Pageable pageable);
 

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardServiceImpl.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardServiceImpl.java
@@ -23,16 +23,19 @@ public class BoardServiceImpl<T> implements BoardService<T> {
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
     private final LikeRepository likeRepository;
+    private final BoardQueryRepository boardQueryRepository;
     private final BoardMapper boardMapper;
 
 
     public BoardServiceImpl(final BoardRepository boardRepository,
                             final MemberRepository memberRepository,
                             final LikeRepository likeRepository,
+                            final BoardQueryRepository boardQueryRepository,
                             final BoardMapper boardMapper) {
         this.boardRepository = boardRepository;
         this.memberRepository = memberRepository;
         this.likeRepository = likeRepository;
+        this.boardQueryRepository = boardQueryRepository;
         this.boardMapper = boardMapper;
     }
 
@@ -83,22 +86,14 @@ public class BoardServiceImpl<T> implements BoardService<T> {
     }
 
     @Override
-    public Slice<SortBoardResponse> getSortedBoards(final String sortBy, final Pageable pageable) {
+    public Slice<SortBoardResponse> getBoardList(final String sortBy,
+                                                 final Pageable pageable) {
 
         final BoardSortType sortType = validateSortType(sortBy.toUpperCase());
-        final Slice<Board> boardSlice = sort(sortType, pageable);
 
         logger.info("[Result] {}를 기준으로 정렬한 게시글 목록 조회", sortBy);
-        return boardMapper.entityToSortBoardResponse(boardSlice);
-    }
 
-    private Slice<Board> sort(final BoardSortType sortType, final Pageable pageable) {
-        return switch (sortType) {
-            case LATEST -> boardRepository.findAllByOrderByCreatedAtDesc(pageable);
-            case VIEWS -> boardRepository.findAllByOrderByViewsDesc(pageable);
-            case LIKES -> boardRepository.findAllByOrderByLikesDesc(pageable);
-            case DEFAULT -> boardRepository.findDefaultBoards(pageable);
-        };
+        return this.boardQueryRepository.boardList(pageable, sortType);
     }
 
     private BoardSortType validateSortType(final String sortBy) {

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/SortBoardResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/SortBoardResponse.java
@@ -7,7 +7,6 @@ public record SortBoardResponse(
         String title,
         String writer,
         LocalDateTime createdAt,
-        int likeCount,
-        int views,
-        boolean isLike) {
+        long likeCount,
+        int views) {
 }

--- a/src/main/java/io/wisoft/wasabi/global/config/common/QueryDslConfig.java
+++ b/src/main/java/io/wisoft/wasabi/global/config/common/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package io.wisoft.wasabi.global.config.common;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    private final EntityManager em;
+
+    public QueryDslConfig(final EntityManager em) {
+        this.em = em;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardControllerTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardControllerTest.java
@@ -5,10 +5,7 @@ import autoparams.customization.Customization;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.wisoft.wasabi.customization.NotSaveBoardCustomization;
 import io.wisoft.wasabi.domain.auth.exception.TokenNotExistException;
-import io.wisoft.wasabi.domain.board.dto.MyBoardsResponse;
-import io.wisoft.wasabi.domain.board.dto.ReadBoardResponse;
-import io.wisoft.wasabi.domain.board.dto.WriteBoardRequest;
-import io.wisoft.wasabi.domain.board.dto.WriteBoardResponse;
+import io.wisoft.wasabi.domain.board.dto.*;
 import io.wisoft.wasabi.domain.like.LikeService;
 import io.wisoft.wasabi.domain.like.dto.RegisterLikeRequest;
 import io.wisoft.wasabi.domain.member.Member;
@@ -158,10 +155,18 @@ class BoardControllerTest {
             //given
             board2.increaseView();
 
-            final var boards = boardMapper.entityToSortBoardResponse(
-                    new SliceImpl<>(List.of(board2, board1)));
+            final var boards = new SliceImpl<>(List.of(board2, board1));
 
-            given(boardService.getSortedBoards(any(), any())).willReturn(boards);
+            final var boardList = boards.map(board -> new SortBoardResponse(
+                    board.getId(),
+                    board.getTitle(),
+                    board.getMember().getName(),
+                    board.getCreatedAt(),
+                    board.getLikes().size(),
+                    board.getViews()
+            ));
+
+            given(boardService.getBoardList(any(), any())).willReturn(boardList);
 
             //when
             final var result = mockMvc.perform(
@@ -180,11 +185,18 @@ class BoardControllerTest {
         void read_boards_order_by_created_at(final Board board1,
                                              final Board board2) throws Exception {
             //given
-            final var boards = boardMapper.entityToSortBoardResponse(
-                    new SliceImpl<>(List.of(board2, board1))
-            );
+            final var boards = new SliceImpl<>(List.of(board2, board1));
 
-            given(boardService.getSortedBoards(any(), any())).willReturn(boards);
+            final var boardList = boards.map(board -> new SortBoardResponse(
+                    board.getId(),
+                    board.getTitle(),
+                    board.getMember().getName(),
+                    board.getCreatedAt(),
+                    board.getLikes().size(),
+                    board.getViews()
+            ));
+
+            given(boardService.getBoardList(any(), any())).willReturn(boardList);
 
             //when
             final var result = mockMvc.perform(
@@ -195,7 +207,6 @@ class BoardControllerTest {
 
             //then
             result.andExpect(status().isOk());
-
         }
 
         @DisplayName("게시글 좋아요 순 정렬 후 조회시, 좋아요가 가장 많은 게시글이 먼저 조회된다.")
@@ -209,11 +220,18 @@ class BoardControllerTest {
             //given
             likeService.registerLike(member.getId(), new RegisterLikeRequest(board1.getId()));
 
-            final var boards = boardMapper.entityToSortBoardResponse(
-                    new SliceImpl<>(List.of(board2, board1))
-            );
+            final var boards = new SliceImpl<>(List.of(board2, board1));
 
-            given(boardService.getSortedBoards(any(), any())).willReturn(boards);
+            final var boardList = boards.map(board -> new SortBoardResponse(
+                    board.getId(),
+                    board.getTitle(),
+                    board.getMember().getName(),
+                    board.getCreatedAt(),
+                    board.getLikes().size(),
+                    board.getViews()
+            ));
+
+            given(boardService.getBoardList(any(), any())).willReturn(boardList);
 
             //when
             final var result = mockMvc.perform(

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardQueryRepositoryTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardQueryRepositoryTest.java
@@ -1,0 +1,111 @@
+package io.wisoft.wasabi.domain.board;
+
+import autoparams.AutoSource;
+import autoparams.customization.Customization;
+import io.wisoft.wasabi.customization.composite.BoardCompositeCustomizer;
+import io.wisoft.wasabi.domain.like.Like;
+import io.wisoft.wasabi.domain.member.Member;
+import io.wisoft.wasabi.setting.QueryDslTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(QueryDslTestConfig.class)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class BoardQueryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private BoardQueryRepository boardQueryRepository;
+
+    @Nested
+    @DisplayName("게시글 목록 정렬 조회")
+    class ReadBoard {
+
+        private final Pageable pageable = PageRequest.of(0, 3);
+
+        @DisplayName("게시글 목록 조회시, 조회수 많은 순으로 졍렬 후 조회에 성공한다.")
+        @ParameterizedTest
+        @AutoSource
+        @Customization(BoardCompositeCustomizer.class)
+        void read_boards_order_by_views(final Member member,
+                                        final List<Board> boards) {
+
+            // given
+            em.persist(member);
+            boardRepository.saveAll(boards);
+
+            final var expected = boards.get(0);
+            expected.increaseView();
+
+            // when
+            final var result = boardQueryRepository.boardList(pageable, BoardSortType.VIEWS);
+
+            // then
+            final var mostViewedBoard = result.getContent().get(0);
+            assertThat(mostViewedBoard.id()).isEqualTo(expected.getId());
+        }
+
+        @DisplayName("게시글 목록 조회시, 최신 순으로 졍렬 후 조회에 성공한다.")
+        @ParameterizedTest
+        @AutoSource
+        @Customization(BoardCompositeCustomizer.class)
+        void read_boards_order_by_create_at(final Member member,
+                                        final List<Board> boards) {
+
+            // given
+            em.persist(member);
+            boardRepository.saveAll(boards);
+
+            final var expected = boards.get(boards.size() - 1);
+
+            // when
+            final var result = boardQueryRepository.boardList(pageable, BoardSortType.LATEST);
+
+            // then
+            final var mostViewedBoard = result.getContent().get(0);
+            assertThat(mostViewedBoard.id()).isEqualTo(expected.getId());
+        }
+
+        @DisplayName("게시글 목록 조회시, 좋아요 많은 순으로 졍렬 후 조회에 성공한다.")
+        @ParameterizedTest
+        @AutoSource
+        @Customization(BoardCompositeCustomizer.class)
+        void read_boards_order_by_likes(final Member member,
+                                        final List<Board> boards) {
+
+            // given
+            em.persist(member);
+            boardRepository.saveAll(boards);
+            em.persist(new Like(member, boards.get(0)));
+
+            final var expected = boards.get(0);
+
+            // when
+            final var result = boardQueryRepository.boardList(pageable, BoardSortType.VIEWS);
+
+            // then
+            final var mostViewedBoard = result.getContent().get(0);
+            assertThat(mostViewedBoard.id()).isEqualTo(expected.getId());
+        }
+    }
+}

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardRepositoryTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardRepositoryTest.java
@@ -2,12 +2,10 @@ package io.wisoft.wasabi.domain.board;
 
 import autoparams.AutoSource;
 import autoparams.customization.Customization;
-import io.wisoft.wasabi.customization.NotSaveBoardCustomization;
 import io.wisoft.wasabi.customization.NotSaveMemberCustomization;
 import io.wisoft.wasabi.customization.composite.BoardCompositeCustomizer;
 import io.wisoft.wasabi.domain.like.Like;
 import io.wisoft.wasabi.domain.member.Member;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,8 +15,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -88,75 +84,6 @@ class BoardRepositoryTest {
                 softAssertions.assertThat(result.getTitle()).isEqualTo(expected.getTitle());
                 softAssertions.assertThat(result.getContent()).isEqualTo(expected.getContent());
             });
-        }
-
-        @DisplayName("게시글 목록 조회시, 조회수 많은 순으로 정렬 후 조회에 성공한다.")
-        @ParameterizedTest
-        @AutoSource
-        @Customization(BoardCompositeCustomizer.class)
-        void read_boards_order_by_views(final Member member,
-                                        final List<Board> boards) {
-
-            //given
-            em.persist(member);
-            boardRepository.saveAll(boards);
-
-            final var expected = boards.get(0);
-            expected.increaseView();
-
-            //when
-            final var result = boardRepository.findAllByOrderByViewsDesc(pageable);
-
-            //then
-            final var mostViewedBoard = result.getContent().get(0);
-
-            assertThat(mostViewedBoard.getId()).isEqualTo(expected.getId());
-        }
-
-        @DisplayName("게시글 목록 조회시, 최신 순으로 정렬 후 조회에 성공한다.")
-        @ParameterizedTest
-        @AutoSource
-        @Customization(BoardCompositeCustomizer.class)
-        void read_boards_order_by_create_at(final Member member,
-                                            final List<Board> boards) {
-
-            //given
-            em.persist(member);
-            boardRepository.saveAll(boards);
-
-            final var expected = boards.get(boards.size() - 1);
-
-            //when
-            final var result = boardRepository.findAllByOrderByCreatedAtDesc(pageable);
-
-            //then
-            final var mostRecentBoard = result.getContent().get(0);
-
-            assertThat(mostRecentBoard.getId()).isEqualTo(expected.getId());
-        }
-
-
-        @DisplayName("게시글 목록 조회시, 좋아요 많은 순 정렬 후 조회에 성공한다.")
-        @ParameterizedTest
-        @AutoSource
-        @Customization(BoardCompositeCustomizer.class)
-        void read_boards_order_by_likes(final Member member,
-                                        final List<Board> boards) {
-
-            //given
-            em.persist(member);
-            boardRepository.saveAll(boards);
-            em.persist(new Like(member, boards.get(0)));
-
-            final var expected = boards.get(0);
-
-            //when
-            final var result = boardRepository.findAllByOrderByLikesDesc(pageable).getContent();
-
-            //then
-            final var mostLikedBoard = result.get(0);
-
-            assertThat(mostLikedBoard.getId()).isEqualTo(expected.getId());
         }
 
         @DisplayName("작성한 게시글 목록 조회 요청시 자신이 작성한 게시글들만 최신순으로 조회된다.")

--- a/src/test/java/io/wisoft/wasabi/domain/board/BoardServiceTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/board/BoardServiceTest.java
@@ -48,6 +48,9 @@ class BoardServiceTest {
     private BoardRepository boardRepository;
 
     @Mock
+    private BoardQueryRepository boardQueryRepository;
+
+    @Mock
     private LikeRepository likeRepository;
 
     @Spy
@@ -122,10 +125,19 @@ class BoardServiceTest {
             board2.increaseView();
 
             final var boards = new SliceImpl<>(List.of(board2, board1));
-            given(boardRepository.findAllByOrderByViewsDesc(pageable)).willReturn(boards);
+            final var boardList = boards.map(board -> new SortBoardResponse(
+                    board.getId(),
+                    board.getTitle(),
+                    board.getMember().getName(),
+                    board.getCreatedAt(),
+                    board.getLikes().size(),
+                    board.getViews()
+            ));
+
+            given(boardQueryRepository.boardList(pageable, BoardSortType.VIEWS)).willReturn(boardList);
 
             //when
-            final var sortedBoards = boardServiceImpl.getSortedBoards("views", pageable);
+            final var sortedBoards = boardServiceImpl.getBoardList("views", pageable);
 
             //then
             final var mostViewedBoard = (SortBoardResponse) sortedBoards.getContent().get(0);
@@ -146,10 +158,19 @@ class BoardServiceTest {
 
             //given
             final var boards = new SliceImpl<>(List.of(board3, board2, board1));
-            given(boardRepository.findAllByOrderByCreatedAtDesc(pageable)).willReturn(boards);
+            final var boardList = boards.map(board -> new SortBoardResponse(
+                    board.getId(),
+                    board.getTitle(),
+                    board.getMember().getName(),
+                    board.getCreatedAt(),
+                    board.getLikes().size(),
+                    board.getViews()
+            ));
+
+            given(boardQueryRepository.boardList(pageable, BoardSortType.LATEST)).willReturn(boardList);
 
             //when
-            final var sortedBoards = boardServiceImpl.getSortedBoards("latest", pageable);
+            final var sortedBoards = boardServiceImpl.getBoardList("latest", pageable);
 
             //then
             final var latestBoard = (SortBoardResponse) sortedBoards.getContent().get(0);
@@ -173,10 +194,19 @@ class BoardServiceTest {
             likeRepository.save(like);
 
             final var boards = new SliceImpl<>(List.of(board2, board1));
-            given(boardRepository.findAllByOrderByLikesDesc(pageable)).willReturn(boards);
+            final var boardList = boards.map(board -> new SortBoardResponse(
+                    board.getId(),
+                    board.getTitle(),
+                    board.getMember().getName(),
+                    board.getCreatedAt(),
+                    board.getLikes().size(),
+                    board.getViews()
+            ));
+
+            given(boardQueryRepository.boardList(pageable, BoardSortType.LIKES)).willReturn(boardList);
 
             //when
-            final var sortedBoards = boardServiceImpl.getSortedBoards("likes", pageable);
+            final var sortedBoards = boardServiceImpl.getBoardList("likes", pageable);
 
             //then
             final var mostLikedBoard = (SortBoardResponse) sortedBoards.getContent().get(0);
@@ -184,7 +214,6 @@ class BoardServiceTest {
                 softAssertions.assertThat(mostLikedBoard.id()).isEqualTo(board2.getId());
                 softAssertions.assertThat(mostLikedBoard.title()).isEqualTo(board2.getTitle());
             });
-
         }
 
         @DisplayName("작성한 게시글 목록 조회 요청시 자신이 작성한 게시글 목록이 최신순으로 조회된다.")

--- a/src/test/java/io/wisoft/wasabi/setting/QueryDslTestConfig.java
+++ b/src/test/java/io/wisoft/wasabi/setting/QueryDslTestConfig.java
@@ -1,0 +1,25 @@
+package io.wisoft.wasabi.setting;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.wisoft.wasabi.domain.board.BoardQueryRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QueryDslTestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public BoardQueryRepository boardQueryRepository() {
+        return new BoardQueryRepository(jpaQueryFactory());
+    }
+}


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: #WA-152, #WA-153
- 게시글 목록 정렬 조회 기능 Query DSL을 사용해 리팩토링

</br>

## Changes📝

- 기존의 게시글 목록 조회 기능을 Query DSL을 사용해서 리팩토링하였습니다.
- 그에 따라 불필요한 매퍼를 제거하였습니다.
- 추가적으로 각 레이어별 테스트를 작성하고, Repository 테스트에서 필요한 Test용 Bean 클래스를 추가하였습니다.