### PR TITLE
feat: 스케줄링을 통해 게시글에 사용되지 않은 불필요한 이미지 자동 삭제 기능 구현(#WA-186)

### DIFF
--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardController.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardController.java
@@ -104,4 +104,17 @@ public class BoardController {
                 )
         );
     }
+
+    @DeleteMapping("/image")
+    public ResponseEntity<Response<DeleteImageResponse>> deleteImage(@RequestBody final DeleteImageRequest request) {
+
+        final DeleteImageResponse data = boardImageService.deleteImage(request);
+
+        return ResponseEntity.ofNullable(
+                Response.of(
+                        ResponseType.BOARD_IMAGE_DELETE_SUCCESS,
+                        data
+                )
+        );
+    }
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardImage.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardImage.java
@@ -39,6 +39,10 @@ public class BoardImage extends BaseTimeEntity {
         return id;
     }
 
+    public String getFileName() {
+        return fileName;
+    }
+
     public String getStoreImagePath() {
         return storeImagePath;
     }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardImageRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardImageRepository.java
@@ -11,4 +11,12 @@ public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
     @Query("SELECT boardImage FROM BoardImage boardImage" +
             " WHERE boardImage.id in :list")
     List<BoardImage> findAllBoardImagesById(@Param("list") final List<Long> boardImageIds);
+
+    @Query("SELECT boardImage FROM BoardImage boardImage" +
+            " WHERE boardImage.board = null")
+    List<BoardImage> findAllBoardImagesByNull();
+
+    @Query("SELECT boardImage FROM BoardImage boardImage" +
+            " WHERE boardImage.storeImagePath = :path")
+    BoardImage findBoardImageByStoreImagePath(@Param("path") final String storeImagePath);
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardImageService.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardImageService.java
@@ -1,9 +1,13 @@
 package io.wisoft.wasabi.domain.board;
 
+import io.wisoft.wasabi.domain.board.dto.DeleteImageRequest;
+import io.wisoft.wasabi.domain.board.dto.DeleteImageResponse;
 import io.wisoft.wasabi.domain.board.dto.UploadImageRequest;
 import io.wisoft.wasabi.domain.board.dto.UploadImageResponse;
 
 public interface BoardImageService {
 
     UploadImageResponse saveImage(final UploadImageRequest request);
+
+    DeleteImageResponse deleteImage(final DeleteImageRequest request);
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
@@ -40,6 +40,33 @@ public class BoardMapper {
         );
     }
 
+    static DeleteImageResponse entityToDeleteImageResponse(final Long imageId) {
+
+        return new DeleteImageResponse(imageId);
+    }
+
+    ReadBoardResponse entityToReadBoardResponse(final Board board, final boolean isLike) {
+
+        return new ReadBoardResponse(
+                board.getId(),
+                board.getTitle(),
+                board.getContent(),
+                new ReadBoardResponse.Writer(
+                        board.getMember().getEmail(),
+                        board.getMember().getName(),
+                        board.getMember().getReferenceUrl(),
+                        board.getMember().getPart(),
+                        board.getMember().getOrganization(),
+                        board.getMember().getMotto()
+                ),
+                board.getCreatedAt(),
+                board.getLikes().size(),
+                board.getViews(),
+                isLike,
+                String.valueOf(board.getTag())
+        );
+    }
+
     static Slice<MyBoardsResponse> entityToMyBoardsResponse(final Slice<Board> myBoards) {
 
         return myBoards.map(board -> new MyBoardsResponse(

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/DeleteImageRequest.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/DeleteImageRequest.java
@@ -1,0 +1,6 @@
+package io.wisoft.wasabi.domain.board.dto;
+
+public record DeleteImageRequest(
+        String storeImagePath
+) {
+}

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/DeleteImageResponse.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/DeleteImageResponse.java
@@ -1,0 +1,6 @@
+package io.wisoft.wasabi.domain.board.dto;
+
+public record DeleteImageResponse(
+        Long imageId
+) {
+}

--- a/src/main/java/io/wisoft/wasabi/global/config/web/response/ResponseType.java
+++ b/src/main/java/io/wisoft/wasabi/global/config/web/response/ResponseType.java
@@ -28,6 +28,7 @@ public enum ResponseType {
     MY_BOARD_LIST_SUCCESS(HttpStatus.OK, "BOARD-S004", "My Board List Success"),
     MY_LIKE_BOARD_LIST_SUCCESS(HttpStatus.OK, "BOARD-S005", "My Like Board List Success"),
     BOARD_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "BOARD_S006", "Board Image Upload Success"),
+    BOARD_IMAGE_DELETE_SUCCESS(HttpStatus.OK, "BOARD_S007", "Board Image Delete Success"),
 
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD-F001", "Board Not Found"),
     SORT_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOARD-F002", "Sort Type Invalid"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,10 @@
 spring:
   profiles:
     include: jwt, bcrypt, aws, real
-#    active: local
+    #    active: local
     group:
       dev: log-dev
       prod: log-prod
       test: test
-
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: WA-186
- 스케줄링을 통해 게시글에 사용되지 않은 불필요한 이미지 자동 삭제 기능 구현

</br>

## Changes📝

- 현재 이미지 등록 로직에서는 이미지를 게시글보다 먼저 등록하고 S3 링크를 사용하는 방식입니다.
- 따라서, 게시글과의 매핑을 위해 연관관계를 null로 두고, 게시글이 등록될 시점에 서로 매핑을 합니다.
- 하지만, 사용자가 이미지를 등록만 하고 게시글을 저장하지 않는다면 저장된 이미지는 불필요한 더미 이미지로 남게됩니다.
- 효율적인 삭제를 위해 스케줄링을 등록하고, 사용자가 이미지를 등록하고 나서 24시간이 지난 후에도 게시글을 저장하지 않는다면 정해진 시간마다 로컬 & S3에 있는 이미지들은 삭제되는 기능을 구현하였습니다.
- 추가적으로 이미지 단 건 삭제 기능을 임시적으로 구현하였습니다. 하지만 회의를 통해 변경될 수 있습니다.