### PR TITLE
Board 관련 로직 리팩토링(#WA-197)

### DIFF
--- a/src/main/java/io/wisoft/wasabi/domain/board/Board.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/Board.java
@@ -99,6 +99,10 @@ public class Board extends BaseTimeEntity {
         return boardImages;
     }
 
+    public Set<AnonymousLike> getAnonymousLikes() {
+        return anonymousLikes;
+    }
+
     public int getViews() {
         return views;
     }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardImageRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardImageRepository.java
@@ -8,15 +8,12 @@ import java.util.List;
 
 public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
 
-    @Query("SELECT boardImage FROM BoardImage boardImage" +
-            " WHERE boardImage.id in :list")
+    @Query("SELECT boardImage FROM BoardImage boardImage WHERE boardImage.id IN :list")
     List<BoardImage> findAllBoardImagesById(@Param("list") final List<Long> boardImageIds);
 
-    @Query("SELECT boardImage FROM BoardImage boardImage" +
-            " WHERE boardImage.board = null")
+    @Query("SELECT boardImage FROM BoardImage boardImage WHERE boardImage.board = NULL")
     List<BoardImage> findAllBoardImagesByNull();
 
-    @Query("SELECT boardImage FROM BoardImage boardImage" +
-            " WHERE boardImage.storeImagePath = :path")
+    @Query("SELECT boardImage FROM BoardImage boardImage WHERE boardImage.storeImagePath = :path")
     BoardImage findBoardImageByStoreImagePath(@Param("path") final String storeImagePath);
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
@@ -45,28 +45,6 @@ public class BoardMapper {
         return new DeleteImageResponse(imageId);
     }
 
-    ReadBoardResponse entityToReadBoardResponse(final Board board, final boolean isLike) {
-
-        return new ReadBoardResponse(
-                board.getId(),
-                board.getTitle(),
-                board.getContent(),
-                new ReadBoardResponse.Writer(
-                        board.getMember().getEmail(),
-                        board.getMember().getName(),
-                        board.getMember().getReferenceUrl(),
-                        board.getMember().getPart(),
-                        board.getMember().getOrganization(),
-                        board.getMember().getMotto()
-                ),
-                board.getCreatedAt(),
-                board.getLikes().size(),
-                board.getViews(),
-                isLike,
-                String.valueOf(board.getTag())
-        );
-    }
-
     static Slice<MyBoardsResponse> entityToMyBoardsResponse(final Slice<Board> myBoards) {
 
         return myBoards.map(board -> new MyBoardsResponse(

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardMapper.java
@@ -52,7 +52,7 @@ public class BoardMapper {
                 board.getTitle(),
                 board.getMember().getName(),
                 board.getCreatedAt(),
-                board.getLikes().size(),
+                board.getLikes().size() + board.getAnonymousLikes().size(),
                 board.getViews()
         ));
     }
@@ -64,7 +64,7 @@ public class BoardMapper {
                 board.getTitle(),
                 board.getMember().getName(),
                 board.getCreatedAt(),
-                board.getLikes().size(),
+                board.getLikes().size() + board.getAnonymousLikes().size(),
                 board.getViews()
         ));
     }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardQueryRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardQueryRepository.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardRepository.java
@@ -10,6 +10,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT board FROM Board board " +
             "LEFT JOIN FETCH board.likes " +
+            "LEFT JOIN FETCH board.anonymousLikes annonyLikes " +
             "JOIN FETCH board.member " +
             "WHERE board.member.id = :memberId " +
             "ORDER BY board.createdAt DESC")
@@ -17,7 +18,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     // 내가 좋아요 한 게시글 목록 조회 - 기본값(최신순)
     @Query("SELECT board FROM Board board" +
-            " JOIN board.likes likes" +
+            " JOIN FETCH board.likes likes" +
+            " LEFT JOIN FETCH board.anonymousLikes annonyLikes" +
             " JOIN FETCH board.member member" +
             " WHERE likes.member.id = :id" +
             " ORDER BY board.createdAt DESC")

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardServiceImpl.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -102,12 +103,10 @@ public class BoardServiceImpl implements BoardService {
     }
 
     private BoardSortType validateSortType(final String sortBy) {
-        for (BoardSortType value : BoardSortType.values()) {
-            if (value.getSortType().equalsIgnoreCase(sortBy.toUpperCase())) {
-                return value;
-            }
-        }
-        throw BoardExceptionExecutor.BoardSortTypeInvalidException();
+        return Arrays.stream(BoardSortType.values())
+                .filter(boardSortType -> boardSortType.getSortType().equalsIgnoreCase(sortBy.toUpperCase()))
+                .findAny()
+                .orElseThrow(BoardExceptionExecutor::BoardSortTypeInvalidException);
     }
 
     @Override

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardSortType.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardSortType.java
@@ -8,7 +8,7 @@ public enum BoardSortType {
 
     private final String sortType;
 
-    BoardSortType(String sortType) {
+    BoardSortType(final String sortType) {
         this.sortType = sortType;
     }
 

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/UploadImageRequest.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/UploadImageRequest.java
@@ -1,9 +1,9 @@
 package io.wisoft.wasabi.domain.board.dto;
 
-import io.wisoft.wasabi.global.config.common.annotation.ValidFile;
+import io.wisoft.wasabi.global.config.common.annotation.FileExtension;
 import org.springframework.web.multipart.MultipartFile;
 
 public record UploadImageRequest(
-        @ValidFile MultipartFile image
+        @FileExtension MultipartFile image
 ) {
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/WriteBoardRequest.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/WriteBoardRequest.java
@@ -2,7 +2,6 @@ package io.wisoft.wasabi.domain.board.dto;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -11,6 +10,6 @@ public record WriteBoardRequest(
         @NotBlank String content,
         @Nullable String tag,
         @Nullable String[] imageUrls,
-        @NotNull List<Long> imageIds
+        @Nullable List<Long> imageIds
 ) {
 }

--- a/src/main/java/io/wisoft/wasabi/global/config/common/Const.java
+++ b/src/main/java/io/wisoft/wasabi/global/config/common/Const.java
@@ -28,4 +28,11 @@ public final class Const {
     public static final String UNKNOWN = "unknown";
     public static final String LOCALHOST = "127.0.0.1";
     public static final String ALL_IP = "0:0:0:0:0:0:0:1";
+
+    /**
+     * 파일 확장자 검증에 사용
+     */
+    public static final String IMAGE_EXTENSION_JPEG = "image/jpeg";
+    public static final String IMAGE_EXTENSION_PNG = "image/png";
+    public static final String IMAGE_EXTENSION_JPG = "image/jpg";
 }

--- a/src/main/java/io/wisoft/wasabi/global/config/common/Const.java
+++ b/src/main/java/io/wisoft/wasabi/global/config/common/Const.java
@@ -30,9 +30,10 @@ public final class Const {
     public static final String ALL_IP = "0:0:0:0:0:0:0:1";
 
     /**
-     * 파일 확장자 검증에 사용
+     * 이미지 파일 확장자
      */
     public static final String IMAGE_EXTENSION_JPEG = "image/jpeg";
     public static final String IMAGE_EXTENSION_PNG = "image/png";
     public static final String IMAGE_EXTENSION_JPG = "image/jpg";
+    public static final String CONTENT_TYPE_IMAGE = "image/";
 }

--- a/src/main/java/io/wisoft/wasabi/global/config/common/annotation/FileExtension.java
+++ b/src/main/java/io/wisoft/wasabi/global/config/common/annotation/FileExtension.java
@@ -10,8 +10,8 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = ValidFileValidator.class)
-public @interface ValidFile {
+@Constraint(validatedBy = FileExtensionValidator.class)
+public @interface FileExtension {
     String message() default "PNG, JPG, JPEG 파일만 업로드 가능합니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};

--- a/src/main/java/io/wisoft/wasabi/global/config/common/annotation/FileExtensionValidator.java
+++ b/src/main/java/io/wisoft/wasabi/global/config/common/annotation/FileExtensionValidator.java
@@ -1,15 +1,16 @@
 package io.wisoft.wasabi.global.config.common.annotation;
 
+import io.wisoft.wasabi.global.config.common.Const;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.springframework.web.multipart.MultipartFile;
 
-public class ValidFileValidator implements ConstraintValidator<ValidFile, MultipartFile> {
+public class FileExtensionValidator implements ConstraintValidator<FileExtension, MultipartFile> {
 
     @Override
     public boolean isValid(final MultipartFile file, final ConstraintValidatorContext context) {
 
-        if(file.isEmpty()){
+        if (file.isEmpty()) {
             return false;
         }
 
@@ -19,9 +20,6 @@ public class ValidFileValidator implements ConstraintValidator<ValidFile, Multip
     }
 
     private static boolean fileVerification(final String contentType) {
-        if (!(contentType == null) && ((contentType.equals("image/jpeg")) || (contentType.equals("image/png")) || (contentType.equals("image/jpg")))) {
-            return true;
-        }
-        return false;
+        return !(contentType == null) && ((contentType.equals(Const.IMAGE_EXTENSION_JPEG)) || (contentType.equals(Const.IMAGE_EXTENSION_PNG)) || (contentType.equals(Const.IMAGE_EXTENSION_JPG)));
     }
 }


### PR DESCRIPTION
- [x] 사용되지 않는 메서드 및 import 문 제거
- [x] 중복 로직 처리
- [x] 문자열 상수화 및 JPQL 작성시 예약 키워드 대문자 변환
- [ ] QueryDSL을 이용해 단일 쿼리로 동작하도록 수정 및 Board 관련 DTO 통합