### PR TITLE
[Merge 금지] feat : @Formula 적용 검토 및 성능 테스트(WA-201)

### DIFF
--- a/src/main/java/io/wisoft/wasabi/domain/board/Board.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/Board.java
@@ -7,6 +7,7 @@ import io.wisoft.wasabi.domain.member.Member;
 import io.wisoft.wasabi.domain.tag.Tag;
 import jakarta.persistence.*;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Formula;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -47,6 +48,20 @@ public class Board extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "board")
     private Set<AnonymousLike> anonymousLikes = new HashSet<>();
+
+    @Formula("(SELECT COUNT(1) FROM likes l WHERE l.board_id = id)")
+    private Long likeCount;
+
+    @Formula("(SELECT COUNT(1) FROM anonymous_likes al WHERE al.board_id = id)")
+    private Long anonymousLikeCount;
+
+    public Long getLikeCount() {
+        return likeCount;
+    }
+
+    public Long getAnonymousLikeCount() {
+        return anonymousLikeCount;
+    }
 
     private void setMember(final Member member) {
         this.member = member;

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardController.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardController.java
@@ -39,12 +39,30 @@ public class BoardController {
         );
     }
 
-    @GetMapping("/{boardId}")
+    @GetMapping("/v1/{boardId}")
     public ResponseEntity<Response<ReadBoardResponse>> readBoard(@PathVariable final Long boardId,
                                                                  @Anyone final Long accessId,
                                                                  @RequestAttribute(value = "isAuthenticated") final boolean isAuthenticated) {
 
         final ReadBoardResponse data = boardService.readBoard(boardId, accessId, isAuthenticated);
+        return ResponseEntity.ofNullable(
+                Response.of(
+                        ResponseType.BOARD_READ_SUCCESS,
+                        data
+                )
+        );
+    }
+
+    /**
+     * 게시글 조회시 @Formular를 이용해 조인이 아닌
+     * 직접 쿼리로 좋아요 갯수를 가져오는 로직을 호출하는 API
+     */
+    @GetMapping("/v2/{boardId}")
+    public ResponseEntity<Response<ReadBoardResponse>> readBoardWithFormula(@PathVariable final Long boardId,
+                                                                 @Anyone final Long accessId,
+                                                                 @RequestAttribute(value = "isAuthenticated") final boolean isAuthenticated) {
+
+        final ReadBoardResponse data = boardService.readBoardWithFomula(boardId, accessId, isAuthenticated);
         return ResponseEntity.ofNullable(
                 Response.of(
                         ResponseType.BOARD_READ_SUCCESS,

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT board FROM Board board " +
@@ -25,4 +27,11 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT EXISTS(SELECT board FROM Board board WHERE board.id = :id)")
     boolean existsById(@Param("id") final Long id);
+
+    /**
+     * Board와 관련된 좋아요는 @Formula로 직접 조회하기 때문에 board.like를 조인할 필요가 없어짐
+     */
+    @Query("SELECT board FROM Board board " +
+            "JOIN FETCH board.member LEFT JOIN FETCH board.tag")
+    Optional<Board> findBoardById(final Long boardId);
 }

--- a/src/main/java/io/wisoft/wasabi/domain/board/BoardService.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/BoardService.java
@@ -9,6 +9,7 @@ public interface BoardService {
     WriteBoardResponse writeBoard(final WriteBoardRequest request, final Long memberId);
 
     ReadBoardResponse readBoard(final Long boardId, final Long accessId, final boolean isAuthenticated);
+    ReadBoardResponse readBoardWithFomula(final Long boardId, final Long accessId, final boolean isAuthenticated);
 
     Slice<SortBoardResponse> getBoardList(final String sortBy, final Pageable pageable, final String keyword);
 

--- a/src/main/java/io/wisoft/wasabi/domain/board/dto/WriteBoardRequest.java
+++ b/src/main/java/io/wisoft/wasabi/domain/board/dto/WriteBoardRequest.java
@@ -2,7 +2,6 @@ package io.wisoft.wasabi.domain.board.dto;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -11,6 +10,6 @@ public record WriteBoardRequest(
         @NotBlank String content,
         @Nullable String tag,
         @Nullable String[] imageUrls,
-        @NotNull List<Long> imageIds
+        @Nullable List<Long> imageIds
 ) {
 }


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: WA-201
- `@Formula` 적용 검토 및 성능 테스트(WA-201)
- 해당 PR 내용은 [노션 링크](https://www.notion.so/Fomula-010356068c9c4eb59b0b0427c9dc49df)에서 더 자세하게 확인하실 수 있습니다.

</br>

## Changes📝

게시글 조회시 좋아요 갯수를 조인을 통해 가져오는 방식이 아닌, `@Formula`를 이용해 쿼리로 가상 필드에 가져오는 방식을 구현해보고 성능 비교를 하였습니다.

- Board : `@Formula`와 함께 가상 필드 선언
- BoardRepository : Board 조회시 Member와 Tag만 조인으로 가져옴 (더이상 Like & AnnonymousLike를 조인으로 가져오지 않음)
- BoardService : 응답 DTO에 Board를 조회하며 값이 할당된 가상 필드 값을 할당

<br/>

## 성능 테스트
#### 테스트 환경
- MacOS M1 16G Memory
- Java 17
- Spring Boot 3.1.0
- Tomcat
- Thread Pool (Tomcat)
    - Spring Boot 디폴트 값 사용
    - max : 200                                *# 생성할 수 있는 thread의 총 개수*
    - min-spare: 10                          *# 항상 활성화 되어있는(idle) thread의 개수*
    - max-connections: 8192         *# 수립가능한 connection의 총 개수*
    - accept-count: 100                  *# 작업큐의 사이즈*
    - connection-timeout: 20000 *# timeout 판단 기준 시간, 20초*
- Database Connection Pool
    - HikariCP 디폴트 값 사용
    - connection-timeout: 30000 # 타임아웃 값
    - validation-timeout: 5000  # 유효한 타임아웃
    - minimum-idle: 10          # 유휴 커넥션 수
    - max-lifetime: 1800000     # 커넥션의 최대 수명
    - maximum-pool-size: 10     # 최대 풀 사이즈
    - idle-timeout: 600000      # 연결을 위한 최대 유휴 시간
    - auto-commit: true         # auto commit 여부

#### Apache Jmeter 설정
- Number of Threads(users) : 1000
- Ramp-up period(seconds) : 1
- Loop Count : 10

#### 데이터 설정
- 회원 및 익명 사용자의 좋아요를 사전에 30개 등록

#### 테스트 결과
아주 미세하게 처리량(Throughput)이 `@Formular` 를 사용한 방식이 0.8/sec 정도 앞선다.

</br>

## Screen Shot📷

![스크린샷 2023-12-15 오전 12 15 24](https://github.com/Wisoft-Wasabi/wasabi-backend/assets/95692663/b09cfc2f-7738-4257-bc7c-5c3c179a9e3f)

