### PR TITLE
refactor: 관리자와 좋아요 로직 및 단위 테스트 리팩토링(#WA-240)

### DIFF
--- a/src/main/java/io/wisoft/wasabi/domain/admin/application/AdminServiceImpl.java
+++ b/src/main/java/io/wisoft/wasabi/domain/admin/application/AdminServiceImpl.java
@@ -24,6 +24,7 @@ public class AdminServiceImpl implements AdminService {
     }
 
     public Slice<MembersResponse> getUnapprovedMembers(final Pageable pageable) {
+
         final Slice<Member> members = memberRepository.findMemberByUnactivated(pageable);
 
         logger.info("[Result] 관리자가 승인되지 않은 회원 전체조회");

--- a/src/main/java/io/wisoft/wasabi/domain/admin/web/AdminController.java
+++ b/src/main/java/io/wisoft/wasabi/domain/admin/web/AdminController.java
@@ -25,6 +25,7 @@ public class AdminController {
 
     @GetMapping("/members")
     public ResponseEntity<Response<Slice<MembersResponse>>> getUnapprovedMembers(@PageableDefault final Pageable pageable) {
+
         final Slice<MembersResponse> data = adminService.getUnapprovedMembers(pageable);
 
         return ResponseEntity.ofNullable(
@@ -37,6 +38,7 @@ public class AdminController {
 
     @PatchMapping("/members")
     public ResponseEntity<Response<ApproveMemberResponse>> approveMember(@RequestBody final ApproveMemberRequest request) {
+
         final ApproveMemberResponse data = adminService.approveMember(request);
 
         return ResponseEntity.ofNullable(

--- a/src/main/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeRepository.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 public interface AnonymousLikeRepository extends CrudRepository<AnonymousLike, Long> {
 
     @Query("SELECT like FROM AnonymousLike like WHERE like.sessionId = :sessionId AND like.board.id = :boardId")
-    Optional<AnonymousLike> findBySessionIdAndBoardId(@Param("sessionId") Long sessionId, @Param("boardId") Long boardId);
+    Optional<AnonymousLike> findBySessionIdAndBoardId(@Param("sessionId") final Long sessionId, @Param("boardId") final Long boardId);
 
     @Query("SELECT EXISTS(SELECT like FROM AnonymousLike like WHERE like.sessionId = :sessionId AND like.board.id = :boardId)")
-    boolean existsBySessionIdAndBoardId(@Param("sessionId") Long sessionId, @Param("boardId") Long boardId);
+    boolean existsBySessionIdAndBoardId(@Param("sessionId") final Long sessionId, @Param("boardId") final Long boardId);
 }

--- a/src/main/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeServiceImpl.java
+++ b/src/main/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeServiceImpl.java
@@ -28,6 +28,7 @@ public class AnonymousLikeServiceImpl implements LikeService {
     public AnonymousLikeServiceImpl(final AnonymousLikeRepository anonymousLikeRepository,
                                     final BoardRepository boardRepository,
                                     final LikeQueryRepository likeQueryRepository) {
+
         this.anonymousLikeRepository = anonymousLikeRepository;
         this.boardRepository = boardRepository;
         this.likeQueryRepository = likeQueryRepository;
@@ -66,7 +67,9 @@ public class AnonymousLikeServiceImpl implements LikeService {
 
     @Override
     public GetLikeResponse getLikeStatus(final Long accessId, final Long boardId) {
+
         final boolean isExistsBoard = boardRepository.existsById(boardId);
+
         if (!isExistsBoard) {
             throw BoardExceptionExecutor.BoardNotFound();
         }

--- a/src/main/java/io/wisoft/wasabi/domain/like/application/LikeRepository.java
+++ b/src/main/java/io/wisoft/wasabi/domain/like/application/LikeRepository.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     @Query("SELECT like FROM Like like WHERE like.member.id = :memberId AND like.board.id = :boardId")
-    Optional<Like> findByMemberIdAndBoardId(@Param("memberId") Long memberId, @Param("boardId") Long boardId);
+    Optional<Like> findByMemberIdAndBoardId(@Param("memberId") final Long memberId, @Param("boardId") final Long boardId);
 
     @Query("SELECT EXISTS(SELECT like FROM Like like WHERE like.member.id = :memberId AND like.board.id = :boardId)")
-    boolean existsByMemberIdAndBoardId(@Param("memberId") Long memberId, @Param("boardId") Long boardId);
+    boolean existsByMemberIdAndBoardId(@Param("memberId") final Long memberId, @Param("boardId") final Long boardId);
 }

--- a/src/main/java/io/wisoft/wasabi/domain/like/application/LikeServiceImpl.java
+++ b/src/main/java/io/wisoft/wasabi/domain/like/application/LikeServiceImpl.java
@@ -33,6 +33,7 @@ public class LikeServiceImpl implements LikeService {
                            final MemberRepository memberRepository,
                            final BoardRepository boardRepository,
                            final LikeQueryRepository likeQueryRepository) {
+
         this.likeRepository = likeRepository;
         this.memberRepository = memberRepository;
         this.boardRepository = boardRepository;
@@ -65,6 +66,7 @@ public class LikeServiceImpl implements LikeService {
     @Override
     @Transactional
     public CancelLikeResponse cancelLike(final Long memberId, final Long boardId) {
+
         final Like like = likeRepository.findByMemberIdAndBoardId(memberId, boardId)
                 .orElseThrow(LikeExceptionExecutor::LikeNotFound);
 
@@ -78,6 +80,7 @@ public class LikeServiceImpl implements LikeService {
     public GetLikeResponse getLikeStatus(final Long memberId, final Long boardId) {
 
         final boolean isExistsBoard = boardRepository.existsById(boardId);
+
         if (!isExistsBoard) {
             throw BoardExceptionExecutor.BoardNotFound();
         }

--- a/src/main/java/io/wisoft/wasabi/domain/like/web/LikeController.java
+++ b/src/main/java/io/wisoft/wasabi/domain/like/web/LikeController.java
@@ -21,6 +21,7 @@ public class LikeController {
 
     public LikeController(@Qualifier("likeService") final LikeService likeService,
                           @Qualifier("anonymousLikeService") final LikeService anonymousLikeService) {
+
         this.likeService = likeService;
         this.anonymousLikeService = anonymousLikeService;
     }

--- a/src/main/java/io/wisoft/wasabi/global/config/web/response/ResponseType.java
+++ b/src/main/java/io/wisoft/wasabi/global/config/web/response/ResponseType.java
@@ -21,7 +21,7 @@ public enum ResponseType {
     READ_MEMBER_UN_APPROVE_SUCCESS(HttpStatus.OK, "MEMBER-S004", "Read Member Unapprove Success"),
     DELETE_SIGN_UP_SUCCESS(HttpStatus.OK, "MEMBER_S005", "Delete Sign Up Requests Success"),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-F001", "User Not Found"),
-    MEMBER_EMAIL_OVERLAP(HttpStatus.CONFLICT, "MEMBER-F003", "User Email Overlap"),
+    MEMBER_EMAIL_OVERLAP(HttpStatus.CONFLICT, "MEMBER-F002", "User Email Overlap"),
 
     /* 게시글 - BOARD */
     BOARD_WRITE_SUCCESS(HttpStatus.CREATED, "BOARD-S001", "Board Write Success"),
@@ -34,7 +34,7 @@ public enum ResponseType {
 
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD-F001", "Board Not Found"),
     SORT_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOARD-F002", "Sort Type Invalid"),
-    BOARD_IMAGE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "BOARD_F003", "Board Image Upload Fail"),
+    BOARD_IMAGE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "BOARD-F003", "Board Image Upload Fail"),
 
     /* 좋아요 - LIKE */
     LIKE_REGISTER_SUCCESS(HttpStatus.CREATED, "LIKE-S001", "Like Register Success"),

--- a/src/test/java/io/wisoft/wasabi/domain/admin/web/AdminControllerTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/admin/web/AdminControllerTest.java
@@ -2,14 +2,12 @@ package io.wisoft.wasabi.domain.admin.web;
 
 import autoparams.AutoSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.wisoft.wasabi.domain.admin.web.dto.ApproveMemberRequest;
-import io.wisoft.wasabi.domain.admin.web.dto.DeleteSignUpRequest;
-import io.wisoft.wasabi.domain.admin.web.dto.DeleteSignUpResponse;
-import io.wisoft.wasabi.domain.member.application.MemberRepository;
+import io.wisoft.wasabi.domain.admin.web.dto.*;
 import io.wisoft.wasabi.domain.member.persistence.Role;
 import io.wisoft.wasabi.global.config.common.Const;
 import io.wisoft.wasabi.global.config.common.jwt.JwtTokenProvider;
 import io.wisoft.wasabi.global.config.web.response.ResponseAspect;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,7 +17,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -27,6 +29,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(controllers = AdminController.class)
 public class AdminControllerTest {
 
@@ -39,56 +42,76 @@ public class AdminControllerTest {
     @SpyBean
     private JwtTokenProvider jwtTokenProvider;
 
-    @MockBean
-    private MemberRepository memberRepository;
-
     @Spy
     private ObjectMapper objectMapper;
 
     @SpyBean
     private ResponseAspect responseAspect;
 
+    private String accessToken;
+
+    @BeforeEach
+    void createToken() {
+        accessToken = jwtTokenProvider.createAccessToken(
+                1L,
+                "admin",
+                Role.ADMIN,
+                true
+        );
+    }
+
     @Nested
     @DisplayName("승인되지 않은 회원 조회")
-    class getUnapprovedMembers {
-        final String token = jwtTokenProvider.createAccessToken(1L, "admin", Role.ADMIN, true);
+    class ReadUnapprovedMembers {
 
         @DisplayName("관리자가 승인되지 않은 회원을 조회한다.")
-        @Test
-        void getUnapprovedMembers() throws Exception {
-            // given
-
-            // when
-            final var result = mockMvc.perform(get("/admin/members")
-                    .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + token)
-                    .contentType(APPLICATION_JSON));
-
-            // then
-            result.andExpect(status().isOk());
-        }
-
-        @DisplayName("관리자가 회원을 승인한다.")
         @ParameterizedTest
         @AutoSource
-        void approveMember(final ApproveMemberRequest request) throws Exception {
+        void read_unapproved_members(final List<MembersResponse> membersResponses) throws Exception {
+
             // given
+            given(adminService.getUnapprovedMembers(any())).willReturn(new SliceImpl<>(membersResponses));
 
             // when
-            final var result = mockMvc.perform(patch("/admin/members")
-                    .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + token)
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(APPLICATION_JSON));
+            final var result = mockMvc.perform(
+                    get("/admin/members")
+                            .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + accessToken)
+                            .contentType(APPLICATION_JSON));
 
             // then
             result.andExpect(status().isOk());
         }
+    }
 
+    @Nested
+    @DisplayName("승인되지 않은 유저 승인(활성화)")
+    class UpdateApproveActivateMember {
+
+        @DisplayName("관리자가 승인되지 않은 회원을 승인한다.")
+        @ParameterizedTest
+        @AutoSource
+        void update_approve_activate_member(final ApproveMemberRequest request) throws Exception {
+
+            // given
+            final var response = new ApproveMemberResponse(1L);
+
+            given(adminService.approveMember(any())).willReturn(response);
+
+            // when
+            final var result = mockMvc.perform(
+                    patch("/admin/members")
+                            .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(APPLICATION_JSON));
+
+            // then
+            result.andExpect(status().isOk());
+        }
     }
 
     @Nested
     @DisplayName("회원 가입 요청 삭제")
     class DeleteSignUp {
-        final String token = jwtTokenProvider.createAccessToken(1L, "admin", Role.ADMIN, true);
 
         @DisplayName("회원 가입 요청들을 정상적으로 삭제한다.")
         @ParameterizedTest
@@ -101,30 +124,31 @@ public class AdminControllerTest {
             given(adminService.deleteSignUp(any())).willReturn(new DeleteSignUpResponse(request.ids().size()));
 
             // when
-            final var result = mockMvc.perform(delete("/admin/members")
-                    .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + token)
-                    .contentType(APPLICATION_JSON)
-                    .content(content));
+            final var result = mockMvc.perform(
+                    delete("/admin/members")
+                            .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + accessToken)
+                            .content(content)
+                            .contentType(APPLICATION_JSON));
 
             // then
             result.andExpect(status().isOk());
         }
 
+        @Test
         @DisplayName("회원 가입 요청들의 id는 null 이어서는 안된다.")
-        @ParameterizedTest
-        @AutoSource
-        void delete_sign_up_requests_fail1() throws Exception {
+        void delete_sign_up_requests_fail() throws Exception {
 
             // given
-            final DeleteSignUpRequest request = new DeleteSignUpRequest(null);
+            final var request = new DeleteSignUpRequest(null);
 
             final String content = objectMapper.writeValueAsString(request);
 
             // when
-            final var result = mockMvc.perform(delete("/admin/members")
-                    .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + token)
-                    .contentType(APPLICATION_JSON)
-                    .content(content));
+            final var result = mockMvc.perform(
+                    delete("/admin/members")
+                            .header(Const.AUTH_HEADER, Const.TOKEN_TYPE + " " + accessToken)
+                            .content(content)
+                            .contentType(APPLICATION_JSON));
 
             // then
             result.andExpect(status().isBadRequest());

--- a/src/test/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeRepositoryTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeRepositoryTest.java
@@ -4,7 +4,6 @@ import autoparams.AutoSource;
 import autoparams.customization.Customization;
 import io.wisoft.wasabi.customization.composite.BoardCompositeCustomizer;
 import io.wisoft.wasabi.domain.like.persistence.AnonymousLike;
-import io.wisoft.wasabi.domain.like.application.AnonymousLikeRepository;
 import io.wisoft.wasabi.domain.board.persistence.Board;
 import io.wisoft.wasabi.domain.like.exception.LikeExceptionExecutor;
 import io.wisoft.wasabi.domain.member.persistence.Member;
@@ -37,6 +36,7 @@ class AnonymousLikeRepositoryTest {
     private AnonymousLike init(final Member member,
                                final Board board,
                                final Long sessionId) {
+
         em.persist(member);
         em.persist(board);
 

--- a/src/test/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeServiceImplTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/like/application/AnonymousLikeServiceImplTest.java
@@ -2,8 +2,6 @@ package io.wisoft.wasabi.domain.like.application;
 
 import autoparams.AutoSource;
 import io.wisoft.wasabi.domain.like.persistence.AnonymousLike;
-import io.wisoft.wasabi.domain.like.application.AnonymousLikeRepository;
-import io.wisoft.wasabi.domain.like.application.AnonymousLikeServiceImpl;
 import io.wisoft.wasabi.domain.board.persistence.Board;
 import io.wisoft.wasabi.domain.board.application.BoardRepository;
 import io.wisoft.wasabi.domain.like.persistence.LikeQueryRepository;

--- a/src/test/java/io/wisoft/wasabi/domain/like/application/LikeServiceTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/like/application/LikeServiceTest.java
@@ -7,18 +7,15 @@ import io.wisoft.wasabi.customization.NotSaveMemberCustomization;
 import io.wisoft.wasabi.domain.board.persistence.Board;
 import io.wisoft.wasabi.domain.board.application.BoardRepository;
 import io.wisoft.wasabi.domain.board.exception.BoardNotFoundException;
-import io.wisoft.wasabi.domain.like.application.LikeMapper;
-import io.wisoft.wasabi.domain.like.application.LikeServiceImpl;
+import io.wisoft.wasabi.domain.like.exception.ExistLikeException;
 import io.wisoft.wasabi.domain.like.web.dto.RegisterLikeRequest;
 import io.wisoft.wasabi.domain.like.exception.LikeNotFoundException;
 import io.wisoft.wasabi.domain.like.persistence.Like;
 import io.wisoft.wasabi.domain.like.persistence.LikeQueryRepository;
-import io.wisoft.wasabi.domain.like.application.LikeRepository;
+import io.wisoft.wasabi.domain.like.web.dto.RegisterLikeResponse;
 import io.wisoft.wasabi.domain.member.persistence.Member;
 import io.wisoft.wasabi.domain.member.application.MemberRepository;
 import io.wisoft.wasabi.domain.member.exception.MemberNotFoundException;
-import io.wisoft.wasabi.domain.tag.application.TagRepository;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,7 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -46,9 +43,6 @@ class LikeServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private TagRepository tagRepository;
-
-    @Mock
     private BoardRepository boardRepository;
 
     @Mock
@@ -61,35 +55,42 @@ class LikeServiceTest {
     @DisplayName("좋아요 등록")
     class RegisterLike {
 
+        @DisplayName("요청 시 정상적으로 등록되어야 한다.")
         @ParameterizedTest
         @AutoSource
-        @DisplayName("요청 시 정상적으로 등록되어야 한다.")
         @Customization(NotSaveBoardCustomization.class)
-        void register_like(final Member member, final Board board) {
+        void register_like(final Member member,
+                           final Board board) {
 
             //given
             given(memberRepository.findById(any())).willReturn(Optional.of(member));
-
             given(boardRepository.findById(any())).willReturn(Optional.of(board));
+
             final var request = new RegisterLikeRequest(board.getId());
 
-            final var like = LikeMapper.registerLikeRequestToEntity(member, board);
+            final Like like = LikeMapper.registerLikeRequestToEntity(member, board);
+
             given(likeRepository.save(any())).willReturn(like);
 
+            final var response = new RegisterLikeResponse(like.getId());
+
             //when
-            final var response = likeService.registerLike(member.getId(), request);
+            final var result = likeService.registerLike(member.getId(), request);
 
             //then
-            assertNotNull(response);
-            assertThat(response.id()).isEqualTo(like.getId());
+            assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result).isNotNull();
+                softAssertions.assertThat(result.id()).isEqualTo(response.id());
+            });
         }
 
         @Test
-        @DisplayName("존재하지 않는 데이터 요청 시 등록되지 않는다.")
+        @DisplayName("존재하지 않는 유저의 좋아요 요청 시 등록되지 않는다.")
         void register_like_fail() {
 
             //given
             final var request = new RegisterLikeRequest(1L);
+
             given(memberRepository.findById(any())).willReturn(Optional.empty());
 
             //when
@@ -98,36 +99,53 @@ class LikeServiceTest {
             assertThrows(MemberNotFoundException.class,
                     () -> likeService.registerLike(null, request));
         }
+
+        @DisplayName("이미 등록된 좋아요는 중복되어 등록되지 않는다.")
+        @ParameterizedTest
+        @AutoSource
+        void register_like_fail_exist_like(final Member member,
+                                           final Board board) {
+
+            // given
+            given(memberRepository.findById(any())).willReturn(Optional.of(member));
+            given(boardRepository.findById(any())).willReturn(Optional.of(board));
+
+            final var request = new RegisterLikeRequest(board.getId());
+
+            given(likeRepository.existsByMemberIdAndBoardId(any(), any())).willReturn(true);
+
+            // when
+
+            // then
+            assertThrows(ExistLikeException.class,
+                    () -> likeService.registerLike(member.getId(), request));
+        }
     }
 
     @Nested
     @DisplayName("좋아요 취소")
     class CancelLike {
 
-        @DisplayName("요청이 성공적으로 수행되어 정상적으로 응답한다.")
+        @DisplayName("요청이 성공적으로 수행되어 정상적으로 취소된다.")
         @ParameterizedTest
         @AutoSource
         @Customization({
                 NotSaveMemberCustomization.class,
                 NotSaveBoardCustomization.class
         })
-        void cancel_like(
-                final Long memberId,
-                final Long boardId,
-                final Member member,
-                final Board board
-        ) {
+        void cancel_like(final Member member,
+                         final Board board) {
 
             // given
-            final var like = new Like(member, board);
+            final Like like = new Like(member, board);
 
             given(likeRepository.findByMemberIdAndBoardId(any(), any())).willReturn(Optional.of(like));
 
             // when
-            final var result = likeService.cancelLike(memberId, boardId);
+            final var result = likeService.cancelLike(member.getId(), board.getId());
 
             // then
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 softAssertions.assertThat(result).isNotNull();
                 softAssertions.assertThat(like.getMember().getLikes().contains(like)).isFalse();
                 softAssertions.assertThat(like.getBoard().getLikes().contains(like)).isFalse();

--- a/src/test/java/io/wisoft/wasabi/domain/like/persistence/LikeQueryRepositoryTest.java
+++ b/src/test/java/io/wisoft/wasabi/domain/like/persistence/LikeQueryRepositoryTest.java
@@ -4,9 +4,6 @@ import autoparams.AutoSource;
 import autoparams.customization.Customization;
 import io.wisoft.wasabi.customization.composite.BoardCompositeCustomizer;
 import io.wisoft.wasabi.domain.board.persistence.Board;
-import io.wisoft.wasabi.domain.like.persistence.AnonymousLike;
-import io.wisoft.wasabi.domain.like.persistence.Like;
-import io.wisoft.wasabi.domain.like.persistence.LikeQueryRepository;
 import io.wisoft.wasabi.domain.member.persistence.Member;
 import io.wisoft.wasabi.setting.QueryDslTestConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +32,7 @@ class LikeQueryRepositoryTest {
 
     private void init(final Member member,
                       final Board board) {
+
         em.persist(member);
         em.persist(board);
     }


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: WA-240
- 관리자와 좋아요 로직 및 단위 테스트 리팩토링

</br>

## Changes📝

요약글

- 불필요한 import 제거와 사용하지 않는 변수 제거
- 테스트 규약에 맞춰 변수명 수정
- 중복되는 accessToken 생성은 전역 변수로 빼서 `@BeforeEach` 로 초기화
- LikeRepositoryTest 에 좋아요 취소 테스트 추가 (`cancel_like()`)
- LikeServiceTest 에 좋아요 중복 테스트 추가 (`register_like_fail_exist_like()`) 및 좋아요 등록 실패 메시지 구체화
- AdminServiceTest 에 존재하지 않는 유정 대한 실패 테스트 추가 (`update_approve_fail_member_not_found()`)
- AdminControllerTest 에서 클래스명 및 메서드명 수정
